### PR TITLE
Refactor knrk6 device disconnection tests

### DIFF
--- a/system_tests/tests/knrk6.py
+++ b/system_tests/tests/knrk6.py
@@ -46,8 +46,11 @@ class Knrk6Tests(unittest.TestCase):
 
     @skip_if_recsim("Unable to use lewis backdoor in RECSIM")
     def test_GIVEN_device_not_connected_WHEN_get_error_THEN_alarm(self):
-        self._lewis.backdoor_set_on_device('connected', False)
-        self.ca.assert_that_pv_alarm_is('POSITION', ChannelAccess.Alarms.INVALID, timeout=5)
+        self.ca.assert_that_pv_alarm_is('POSITION', ChannelAccess.Alarms.NONE, timeout=5)
+        with self._lewis.backdoor_simulate_disconnected_device():
+            self.ca.assert_that_pv_alarm_is('POSITION', ChannelAccess.Alarms.INVALID, timeout=5)
+        # Assert alarms clear on reconnection
+        self.ca.assert_that_pv_alarm_is('POSITION', ChannelAccess.Alarms.NONE, timeout=5)
 
     @skip_if_recsim("Unable to use lewis backdoor in RECSIM")
     def test_GIVEN_an_input_error_WHEN_open_file_THEN_error_str_returned(self):


### PR DESCRIPTION
**Ticket: https://github.com/ISISComputingGroup/IBEX/issues/7266**
Refactoring all test modules which contain the common behaviour as described in the ticket.

Used new emulator util function instead of old logic
Added in asserts/before main assertions for robustness
Occasionally fixed some tests which threw errors as a result of the above